### PR TITLE
Fix demo props and remove iron flex layout

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "px-alert-message",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "main": [
     "px-alert-message.html"
   ],

--- a/bower.json
+++ b/bower.json
@@ -25,7 +25,6 @@
     "px-alert-message.png"
   ],
   "dependencies": {
-    "iron-flex-layout": "PolymerElements/iron-flex-layout#~1.0.3",
     "polymer": "^1.6.1",
     "px-theme": "^2.0.1",
     "px-buttons-design": "^1.1.0",

--- a/demo/index.html
+++ b/demo/index.html
@@ -148,7 +148,7 @@
         type: String,
         defaultValue: 'Information',
         inputType: 'dropdown',
-        inputChoices: ['Important', 'Warning', 'Error', 'Information', 'More']
+        inputChoices: ['important', 'warning', 'error', 'information', 'more']
       },
       messageTitle: {
         type: String,

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "px-alert-message",
   "author": "General Electric",
   "description": "A Px component providing message notifications",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "private": true,
   "extName": null,
   "repository": {


### PR DESCRIPTION
Hello,

I found that px-alert-message had a dep on iron-flex-layout which I found not being used anywhere. As well as the props in the demo were not right. So fixed that too. Now, changing the type prop updates the demo alert message (it wasn't doing so).

* Removed iron-flex-layout from bower.json
* Changed type prop to lower case from capital case.
* bumped version to 0.8.5 (patch).

PS: iron-flex-layout was using version 1.0.x whereas the paper elements we are using required 1.3.x, so this inspired me to fix this.